### PR TITLE
Fix missing Buffer.concat (#38)

### DIFF
--- a/gramjs/network/connection/TCPAbridged.js
+++ b/gramjs/network/connection/TCPAbridged.js
@@ -17,7 +17,7 @@ class AbridgedPacketCodec extends PacketCodec {
         if (length < 127) {
             length = struct.pack('B', length)
         } else {
-            length = Buffer.from('7f', 'hex') + readBufferFromBigInt(BigInt(length), 3)
+            length = Buffer.concat([Buffer.from('7f', 'hex'), readBufferFromBigInt(BigInt(length), 3)])
         }
         return Buffer.concat([length, data])
     }


### PR DESCRIPTION
Use Buffer.concat instead of "+" when calculating length.

Co-authored-by: Anatoly Turcan <anatolie.turcan@titanium-soft.com>